### PR TITLE
Add Ormolu as default formatter

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,9 @@ dependencies:
 - containers
 - mtl
 
+build-tools:
+- ormolu
+
 ghc-options:
 - -Wall
 - -Werror


### PR DESCRIPTION
Rationale:
- Easy to use, no config required
- Opinionated

This way we get consistency quickly and (potentially) could enforce it on CI.
