### PR TITLE
Parser combinators improvements

### DIFF
--- a/ParserCombinators.hs
+++ b/ParserCombinators.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE LambdaCase #-}
-
-module ParserCombinators (eof, oneof, opt, Parser, Result, rpt, rptSep, rptDropSep, satisfy, token, (<|>)) where
+module ParserCombinators (eof, oneof, opt, Parser, Result, rpt, rptSep, rptDropSep, satisfy, token, tokens, string, (<|>), alt, some, sepBy, sepBy1, between, skip, lookAhead, chainl1, chainr1, parse) where
 
 import Control.Monad.Except (catchError, throwError)
-import Control.Monad.State.Lazy (StateT, get, put)
+import Control.Monad.State.Lazy (StateT, get, put, runStateT)
+import qualified Data.Functor
 
 -- Parse combinators:
 --
@@ -38,15 +37,15 @@ type Parser t = StateT [t] Result
 -- Succeed if there are no more tokens, fail otherwise
 eof :: (Show t) => Parser t ()
 eof = do
-  tokens <- get
-  case tokens of
+  ts <- get
+  case ts of
     [] -> return ()
-    _ -> throwError $ "expected eof but found: " ++ show tokens
+    _ -> throwError $ "expected eof but found: " ++ show ts
 
 satisfy :: (Show t) => (t -> Maybe a) -> Parser t a
 satisfy p = do
-  tokens <- get
-  case tokens of
+  ts <- get
+  case ts of
     [] -> throwError "out of tokens" -- need better error reporting
     (t : rest) -> do
       case p t of
@@ -57,8 +56,8 @@ satisfy p = do
 
 token :: (Show t, Eq t) => t -> Parser t t
 token t = do
-  tokens <- get
-  case tokens of
+  ts <- get
+  case ts of
     [] -> throwError "out of tokens"
     (t' : rest) ->
       if t == t'
@@ -67,21 +66,20 @@ token t = do
           return t
         else throwError ("expected " ++ show t ++ ", found " ++ show (t' : rest))
 
-(<|>) :: Parser t a -> Parser t b -> Parser t (Either a b)
-p1 <|> p2 =
+-- Choice operator: try first parser, if it fails try second
+(<|>) :: Parser t a -> Parser t a -> Parser t a
+p1 <|> p2 = catchError p1 (const p2)
+
+-- Alternative operator that preserves both types
+alt :: Parser t a -> Parser t b -> Parser t (Either a b)
+alt p1 p2 =
   catchError
     (Left <$> p1)
     (\_ -> Right <$> p2)
 
 oneof :: [Parser t a] -> Parser t a
 oneof [] = throwError "no choices left in oneof" -- need better error reporting
-oneof (p : ps) =
-  fmap
-    ( \case
-        (Left a) -> a
-        (Right a) -> a
-    )
-    (p <|> oneof ps)
+oneof (p : ps) = p <|> oneof ps
 
 opt :: Parser t a -> Parser t (Maybe a)
 opt p =
@@ -120,3 +118,80 @@ rptSep p sep =
 
 rptDropSep :: Parser t a -> Parser t b -> Parser t [a]
 rptDropSep p sep = dropSep <$> rptSep p sep
+
+-- One or more repetitions
+some :: Parser t a -> Parser t [a]
+some p = do
+  x <- p
+  xs <- rpt p
+  return (x : xs)
+
+-- Parse zero or more occurrences separated by a separator
+sepBy :: Parser t a -> Parser t sep -> Parser t [a]
+sepBy p sep = sepBy1 p sep <|> return []
+
+-- Parse one or more occurrences separated by a separator
+sepBy1 :: Parser t a -> Parser t sep -> Parser t [a]
+sepBy1 p sep = do
+  x <- p
+  xs <- rpt (sep *> p)
+  return (x : xs)
+
+-- Parse between delimiters
+between :: Parser t open -> Parser t close -> Parser t a -> Parser t a
+between open close p = open *> p <* close
+
+-- Skip/ignore result
+skip :: Parser t a -> Parser t ()
+skip p = p Data.Functor.$> ()
+
+-- Parse with lookahead (don't consume)
+lookAhead :: Parser t a -> Parser t a
+lookAhead p = do
+  ts <- get
+  result <- p
+  put ts
+  return result
+
+-- Left-associative chaining: parses "1 + 2 + 3" as "(1 + 2) + 3"
+chainl1 :: Parser t a -> Parser t (a -> a -> a) -> Parser t a
+chainl1 p op = do
+  x <- p
+  rest x
+  where
+    rest x =
+      ( do
+          f <- op
+          y <- p
+          rest (f x y)
+      )
+        <|> return x
+
+-- Right-associative chaining: parses "1 ^ 2 ^ 3" as "1 ^ (2 ^ 3)"
+chainr1 :: Parser t a -> Parser t (a -> a -> a) -> Parser t a
+chainr1 p op = do
+  x <- p
+  ( do
+      f <- op
+      y <- chainr1 p op
+      return (f x y)
+    )
+    <|> return x
+
+-- Match a specific sequence of tokens
+tokens :: (Show t, Eq t) => [t] -> Parser t [t]
+tokens [] = return []
+tokens (t : ts) = do
+  _ <- token t
+  _ <- tokens ts
+  return (t : ts)
+
+-- Convenient alias for parsing strings
+string :: String -> Parser Char String
+string = tokens
+
+-- Run parser and ensure EOF
+parse :: (Show t) => Parser t a -> [t] -> Result a
+parse p ts = do
+  (result, _) <- runStateT (p <* eof) ts
+  return result

--- a/test/ParserCombinatorsSpec.hs
+++ b/test/ParserCombinatorsSpec.hs
@@ -30,10 +30,22 @@ spec = do
   describe "<|>" $ do
     it "chooses the first parser if it succeeds" $ do
       let p = token 1 <|> token 2
-      runStateT (p :: Parser Int (Either Int Int)) [1, 2] `shouldBe` Right (Left 1, [2])
+      runStateT (p :: Parser Int Int) [1, 2] `shouldBe` Right (1, [2])
     it "chooses the second parser if the first fails" $ do
       let p = token 1 <|> token 2
-      runStateT (p :: Parser Int (Either Int Int)) [2, 1] `shouldBe` Right (Right 2, [1])
+      runStateT (p :: Parser Int Int) [2, 1] `shouldBe` Right (2, [1])
+
+  describe "alt" $ do
+    it "returns Left if the first parser succeeds" $ do
+      let p1 = token 1 :: Parser Int Int
+      let p2 = satisfy (\x -> if x > 5 then Just (show x) else Nothing) :: Parser Int String
+      let p = alt p1 p2
+      runStateT p [1, 2] `shouldBe` Right (Left 1, [2])
+    it "returns Right if the first parser fails and second succeeds" $ do
+      let p1 = token 1 :: Parser Int Int
+      let p2 = satisfy (\x -> if x > 5 then Just (show x) else Nothing) :: Parser Int String
+      let p = alt p1 p2
+      runStateT p [10, 1] `shouldBe` Right (Right "10", [1])
 
   describe "oneof" $ do
     it "picks the first successful parser" $ do
@@ -62,3 +74,100 @@ spec = do
       let p = rptDropSep (token '1') (token '0')
       runStateT p ['1', '0', '1', '2'] `shouldBe` Right (['1', '1'], ['2'])
       runStateT p ['2', '1', '0'] `shouldBe` Right ([], ['2', '1', '0'])
+
+  describe "some" $ do
+    it "parses one or more occurrences" $ do
+      runStateT (some (token '1')) ['1', '1', '2'] `shouldBe` Right (['1', '1'], ['2'])
+    it "fails if no occurrences found" $ do
+      case runStateT (some (token '1')) ['2', '1', '1'] of
+        Left _ -> return ()
+        Right _ -> expectationFailure "Expected failure but got success"
+
+  describe "sepBy" $ do
+    it "parses zero or more occurrences separated by a separator" $ do
+      let p = sepBy (token '1') (token '0')
+      runStateT p ['1', '0', '1', '2'] `shouldBe` Right (['1', '1'], ['2'])
+      runStateT p ['2', '1', '0'] `shouldBe` Right ([], ['2', '1', '0'])
+
+  describe "sepBy1" $ do
+    it "parses one or more occurrences separated by a separator" $ do
+      let p = sepBy1 (token '1') (token '0')
+      runStateT p ['1', '0', '1', '2'] `shouldBe` Right (['1', '1'], ['2'])
+      runStateT p ['1', '2'] `shouldBe` Right (['1'], ['2'])
+    it "fails if no occurrences found" $ do
+      case runStateT (sepBy1 (token '1') (token '0')) ['2', '1', '0'] of
+        Left _ -> return ()
+        Right _ -> expectationFailure "Expected failure but got success"
+
+  describe "between" $ do
+    it "parses content between delimiters" $ do
+      let p = between (token '(') (token ')') (token 'x')
+      runStateT p ['(', 'x', ')', 'y'] `shouldBe` Right ('x', ['y'])
+
+  describe "skip" $ do
+    it "ignores the result of a parser" $ do
+      let p = skip (token '1')
+      runStateT p ['1', '2'] `shouldBe` Right ((), ['2'])
+
+  describe "lookAhead" $ do
+    it "parses without consuming input" $ do
+      let p = lookAhead (token '1')
+      runStateT p ['1', '2'] `shouldBe` Right ('1', ['1', '2'])
+
+  describe "parse" $ do
+    it "runs parser and ensures EOF" $ do
+      let p = token '1'
+      parse p ['1'] `shouldBe` Right '1'
+    it "fails if input remains after parsing" $ do
+      let p = token '1'
+      case parse p ['1', '2'] of
+        Left _ -> return ()
+        Right _ -> expectationFailure "Expected failure but got success"
+
+  describe "chainl1" $ do
+    it "parses left-associative expressions" $ do
+      let num = satisfy (\c -> if c >= '0' && c <= '9' then Just (fromEnum c - fromEnum '0') else Nothing)
+      let plus = token '+' *> return (+)
+      let p = chainl1 num plus
+      runStateT p ['1', '+', '2', '+', '3'] `shouldBe` Right (6, [])
+    it "handles single value without operators" $ do
+      let num = satisfy (\c -> if c >= '0' && c <= '9' then Just (fromEnum c - fromEnum '0') else Nothing)
+      let plus = token '+' *> return (+)
+      let p = chainl1 num plus
+      runStateT p ['5'] `shouldBe` Right (5, [])
+
+  describe "chainr1" $ do
+    it "parses right-associative expressions" $ do
+      let num = satisfy (\c -> if c >= '0' && c <= '9' then Just (fromEnum c - fromEnum '0') else Nothing)
+      let minus = token '-' *> return (-)
+      let p = chainr1 num minus
+      -- 5 - 3 - 1 should be parsed as 5 - (3 - 1) = 3
+      runStateT p ['5', '-', '3', '-', '1'] `shouldBe` Right (3, [])
+    it "handles single value without operators" $ do
+      let num = satisfy (\c -> if c >= '0' && c <= '9' then Just (fromEnum c - fromEnum '0') else Nothing)
+      let minus = token '-' *> return (-)
+      let p = chainr1 num minus
+      runStateT p ['5'] `shouldBe` Right (5, [])
+
+  describe "tokens" $ do
+    it "matches a sequence of tokens" $ do
+      let p = tokens ['a', 'b', 'c']
+      runStateT p ['a', 'b', 'c', 'd'] `shouldBe` Right (['a', 'b', 'c'], ['d'])
+    it "fails if sequence doesn't match" $ do
+      let p = tokens ['a', 'b', 'c']
+      case runStateT p ['a', 'x', 'c'] of
+        Left _ -> return ()
+        Right _ -> expectationFailure "Expected failure but got success"
+    it "succeeds on empty sequence" $ do
+      let p = tokens ([] :: [Char])
+      runStateT p ['a', 'b'] `shouldBe` Right ([], ['a', 'b'])
+
+  describe "string" $ do
+    it "matches a string" $ do
+      let p = string "hello"
+      runStateT p "hello world" `shouldBe` Right ("hello", " world")
+    it "fails if string doesn't match" $ do
+      let p = string "hello"
+      case runStateT p "help" of
+        Left _ -> return ()
+        Right _ -> expectationFailure "Expected failure but got success"


### PR DESCRIPTION
Enhances the parser combinator library with commonly-needed functionality:

**Breaking Changes:**
- Fix `(<|>)` to return `Parser t a` instead of `Parser t (Either a b)`
- Add `alt` for heterogeneous choice (preserves old `(<|>)` behavior)

**New Combinators:**
- `some`: one or more repetitions
- `sepBy`/`sepBy1`: cleaner separator-based repetition
- `chainl1`/`chainr1`: left/right associative operator chaining for expression parsing
- `tokens`/`string`: match token sequences
- `between`, `skip`, `lookAhead`: common utilities

**Convenience:**
- `parse`: runner function that ensures EOF