### PR TITLE
Use Local Version of GHC

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: haskell-actions/setup@v2
       with:
-        ghc-version: '9.4.8'
+        ghc-version: '9.6.7'
         stack-version: '2.15.1'
 
     - name: Build

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # snapshot: ./custom-snapshot.yaml
 # snapshot: https://example.com/snapshots/2024-01-01.yaml
 snapshot:
-    lts-23.0 
+    lts-22.44
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -65,3 +65,6 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+system-ghc: true
+compiler: ghc-9.6.7
+compiler-check: newer-minor

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 9444fadfa30b67a93080254d53872478c087592ad64443e47c546cdcd13149ae
-    size: 678857
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/0.yaml
-  original: lts-23.0
+    sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9
+    size: 721141
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
+  original: lts-22.44


### PR DESCRIPTION
Previously the project would download a newer version of GHC locally. This is quite bad on the lab machines where we can all use Gheith's shared copy without spending our quota space on another copy of GHC.