### PR TITLE
Rewrite machine using catamorphisms

### DIFF
--- a/MachineState.hs
+++ b/MachineState.hs
@@ -1,0 +1,123 @@
+module MachineState
+  ( MachineState (..),
+    emptyMachine,
+    machineOps,
+  )
+where
+
+import Control.Monad.State (StateT)
+import qualified Control.Monad.State as S
+import Control.Monad.Trans.Class (lift)
+import qualified Data.Map as M
+import Small (MachineOps (..))
+import Value (Value (..))
+
+data MachineState = MachineState
+  { machineMemory :: M.Map String Value,
+    machineInputs :: [Value],
+    machineOutputs :: [Value]
+  }
+  deriving (Eq, Show)
+
+emptyMachine :: MachineState
+emptyMachine = MachineState M.empty [] []
+
+type Exec a = StateT MachineState (Either String) a
+
+machineOps :: MachineOps MachineState
+machineOps =
+  MachineOps
+    { machineGetVar = getVar,
+      machineSetVar = setVar,
+      machineInput = inputVal,
+      machineOutput = outputVal,
+      machineAdd = numeric "addition" (+),
+      machineSub = numeric "subtraction" (-),
+      machineMul = numeric "multiplication" (*),
+      machineDiv = divOp,
+      machineMod = modOp,
+      machineLt = numericCmp "<" (<),
+      machineGt = numericCmp ">" (>),
+      machineLte = numericCmp "<=" (<=),
+      machineGte = numericCmp ">=" (>=),
+      machineEq = equality,
+      machineNeq = inequality,
+      machineAnd = boolBinary "&&" (&&),
+      machineOr = boolBinary "||" (||),
+      machineNot = boolUnary "!"
+    }
+  where
+    throw :: String -> Exec a
+    throw msg = lift (Left msg)
+
+    getVar :: String -> Exec Value
+    getVar name = do
+      MachineState mem _ _ <- S.get
+      case M.lookup name mem of
+        Just v -> pure v
+        Nothing -> throw $ "get: " ++ name ++ " not found"
+
+    setVar :: String -> Value -> Exec Value
+    setVar name val = do
+      MachineState mem inp out <- S.get
+      let mem' = M.insert name val mem
+      S.put (MachineState mem' inp out)
+      pure val
+
+    inputVal :: Exec Value
+    inputVal = do
+      MachineState mem inp out <- S.get
+      case inp of
+        (x : xs) -> do
+          S.put (MachineState mem xs out)
+          pure x
+        [] -> throw "Input stream is empty"
+
+    outputVal :: Value -> Exec Value
+    outputVal val = do
+      MachineState mem inp out <- S.get
+      let out' = out ++ [val]
+      S.put (MachineState mem inp out')
+      pure val
+
+    numeric :: String -> (Integer -> Integer -> Integer) -> Value -> Value -> Exec Value
+    numeric _label op (IntVal v1) (IntVal v2) = pure (IntVal (op v1 v2))
+    numeric label _ _ _ = throw $ "Type error in " ++ label
+
+    divOp :: Value -> Value -> Exec Value
+    divOp (IntVal v1) (IntVal v2)
+      | v2 == 0 = throw "Cannot divide by 0"
+      | otherwise = pure (IntVal (v1 `div` v2))
+    divOp _ _ = throw "Type error in division"
+
+    modOp :: Value -> Value -> Exec Value
+    modOp (IntVal v1) (IntVal v2)
+      | v2 == 0 = throw "Cannot mod by 0"
+      | otherwise = pure (IntVal (v1 `mod` v2))
+    modOp _ _ = throw "Type error in modulus"
+
+    numericCmp :: String -> (Integer -> Integer -> Bool) -> Value -> Value -> Exec Value
+    numericCmp _label op (IntVal v1) (IntVal v2) = pure (BoolVal (op v1 v2))
+    numericCmp label _ _ _ = throw $ "Type error in " ++ label
+
+    equality :: Value -> Value -> Exec Value
+    equality (IntVal v1) (IntVal v2) = pure (BoolVal (v1 == v2))
+    equality (BoolVal v1) (BoolVal v2) = pure (BoolVal (v1 == v2))
+    equality (StringVal v1) (StringVal v2) = pure (BoolVal (v1 == v2))
+    equality v1 v2 =
+      throw $ "Type error in ==: cannot compare " ++ show v1 ++ " and " ++ show v2
+
+    inequality :: Value -> Value -> Exec Value
+    inequality (IntVal v1) (IntVal v2) = pure (BoolVal (v1 /= v2))
+    inequality (BoolVal v1) (BoolVal v2) = pure (BoolVal (v1 /= v2))
+    inequality (StringVal v1) (StringVal v2) = pure (BoolVal (v1 /= v2))
+    inequality v1 v2 =
+      throw $ "Type error in !=: cannot compare " ++ show v1 ++ " and " ++ show v2
+
+    boolBinary :: String -> (Bool -> Bool -> Bool) -> Value -> Value -> Exec Value
+    boolBinary _label op (BoolVal v1) (BoolVal v2) = pure (BoolVal (op v1 v2))
+    boolBinary label _ _ _ = throw $ "Type error in " ++ label
+
+    boolUnary :: String -> Value -> Exec Value
+    boolUnary _ (BoolVal v) = pure (BoolVal (not v))
+    boolUnary label _ = throw $ "Type error in " ++ label

--- a/Term.hs
+++ b/Term.hs
@@ -1,4 +1,14 @@
-module Term (Term (..), BinaryOp (..)) where
+{-# LANGUAGE DeriveTraversable #-}
+
+module Term
+  ( Term (..),
+    BinaryOp (..),
+    TermF (..),
+    projectTerm,
+    embedTerm,
+    paraTermM,
+  )
+where
 
 data BinaryOp = Add | Sub | Mul | Div | Mod
   deriving (Eq, Show)
@@ -26,3 +36,78 @@ data Term
   | Or Term Term
   | Not Term
   deriving (Eq, Show)
+
+data TermF a
+  = IfF a a a
+  | LetF String a
+  | LiteralF Integer
+  | StringLiteralF String
+  | ReadF String
+  | SeqF a a
+  | SkipF
+  | BinaryOpsF BinaryOp a a
+  | VarF String
+  | WhileF a a
+  | WriteF a
+  | BoolLitF Bool
+  | LtF a a
+  | GtF a a
+  | LteF a a
+  | GteF a a
+  | EqF a a
+  | NeqF a a
+  | AndF a a
+  | OrF a a
+  | NotF a
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+projectTerm :: Term -> TermF Term
+projectTerm (If c t e) = IfF c t e
+projectTerm (Let name body) = LetF name body
+projectTerm (Literal n) = LiteralF n
+projectTerm (StringLiteral s) = StringLiteralF s
+projectTerm (Read name) = ReadF name
+projectTerm (Seq t1 t2) = SeqF t1 t2
+projectTerm Skip = SkipF
+projectTerm (BinaryOps op t1 t2) = BinaryOpsF op t1 t2
+projectTerm (Var name) = VarF name
+projectTerm (While cond body) = WhileF cond body
+projectTerm (Write t) = WriteF t
+projectTerm (BoolLit b) = BoolLitF b
+projectTerm (Lt t1 t2) = LtF t1 t2
+projectTerm (Gt t1 t2) = GtF t1 t2
+projectTerm (Lte t1 t2) = LteF t1 t2
+projectTerm (Gte t1 t2) = GteF t1 t2
+projectTerm (Eq t1 t2) = EqF t1 t2
+projectTerm (Neq t1 t2) = NeqF t1 t2
+projectTerm (And t1 t2) = AndF t1 t2
+projectTerm (Or t1 t2) = OrF t1 t2
+projectTerm (Not t) = NotF t
+
+embedTerm :: TermF Term -> Term
+embedTerm (IfF c t e) = If c t e
+embedTerm (LetF name body) = Let name body
+embedTerm (LiteralF n) = Literal n
+embedTerm (StringLiteralF s) = StringLiteral s
+embedTerm (ReadF name) = Read name
+embedTerm (SeqF t1 t2) = Seq t1 t2
+embedTerm SkipF = Skip
+embedTerm (BinaryOpsF op t1 t2) = BinaryOps op t1 t2
+embedTerm (VarF name) = Var name
+embedTerm (WhileF cond body) = While cond body
+embedTerm (WriteF t) = Write t
+embedTerm (BoolLitF b) = BoolLit b
+embedTerm (LtF t1 t2) = Lt t1 t2
+embedTerm (GtF t1 t2) = Gt t1 t2
+embedTerm (LteF t1 t2) = Lte t1 t2
+embedTerm (GteF t1 t2) = Gte t1 t2
+embedTerm (EqF t1 t2) = Eq t1 t2
+embedTerm (NeqF t1 t2) = Neq t1 t2
+embedTerm (AndF t1 t2) = And t1 t2
+embedTerm (OrF t1 t2) = Or t1 t2
+embedTerm (NotF t) = Not t
+
+paraTermM :: (Monad m) => (TermF (Term, m r) -> m r) -> Term -> m r
+paraTermM alg = go
+  where
+    go term = alg (fmap (\sub -> (sub, go sub)) (projectTerm term))

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - base
 - containers
 - mtl
+- transformers
 
 build-tools:
 - ormolu

--- a/sim/Main.hs
+++ b/sim/Main.hs
@@ -1,122 +1,9 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
-
 module Main (main) where
 
-import qualified Control.Monad.State as S
-import qualified Data.Map as M
+import MachineState (emptyMachine, machineOps)
 import qualified Progs
-import Small (Env, Machine (..), Result (..), reduceFully)
+import Small (reduceFully)
 import Term (Term (..))
-import Value (Value (..))
-
-data Simulator = Simulator (M.Map String Value) [Value] [Value] deriving (Eq, Show)
-
-instance Machine Simulator where
-  type V Simulator = Value
-  getVar :: String -> Env Simulator
-  getVar name = do
-    (Simulator m _ _) <- S.get
-    case M.lookup name m of
-      Just v -> return $ Happy v
-      Nothing -> return $ Sad $ "get: " ++ name ++ " not found"
-
-  setVar :: String -> Value -> Env Simulator
-  setVar name val = do
-    (Simulator m inp out) <- S.get
-    let m' = M.insert name val m
-    S.put (Simulator m' inp out)
-    return $ Happy val
-
-  inputVal :: Env Simulator
-  inputVal = do
-    (Simulator m inp out) <- S.get
-    case inp of
-      (x : xs) -> do
-        S.put (Simulator m xs out)
-        return $ Happy x
-      [] -> return $ Sad "Input stream is empty"
-
-  outputVal :: Value -> Env Simulator
-  outputVal val = do
-    (Simulator m inp out) <- S.get
-    let out' = out ++ [val]
-    S.put (Simulator m inp out')
-    return $ Happy val
-
-  subVal :: Value -> Value -> Env Simulator
-  subVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 - v2))
-  subVal _ _ = return $ Sad "Type error in subtraction"
-
-  addVal :: Value -> Value -> Env Simulator
-  addVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 + v2))
-  addVal _ _ = return $ Sad "Type error in addition"
-
-  mulVal :: Value -> Value -> Env Simulator
-  mulVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 * v2))
-  mulVal _ _ = return $ Sad "Type error in multiplication"
-
-  divVal :: Value -> Value -> Env Simulator
-  divVal (IntVal v1) (IntVal v2) =
-    if v2 == 0
-      then return $ Sad "Cannot divide by 0"
-      else return $ Happy (IntVal (v1 `div` v2)) -- I don't want the actual interpreter to crash
-  divVal _ _ = return $ Sad "Type error in division"
-
-  modVal :: Value -> Value -> Env Simulator
-  modVal (IntVal v1) (IntVal v2) =
-    if v2 == 0
-      then return $ Sad "Cannot mod by 0"
-      else return $ Happy (IntVal (v1 `mod` v2)) -- I don't want the actual interpreter to crash
-  modVal _ _ = return $ Sad "Type error in modulus"
-
-  selectValue :: Value -> Env Simulator -> Env Simulator -> Env Simulator
-  selectValue (BoolVal True) e1 _ = e1
-  selectValue (BoolVal False) _ e2 = e2
-  selectValue (IntVal n) e1 e2 = if n /= 0 then e1 else e2 -- backward compat
-  selectValue (StringVal s) e1 e2 = if not (null s) then e1 else e2
-
-  ltVal :: Value -> Value -> Env Simulator
-  ltVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 < v2))
-  ltVal _ _ = return $ Sad "Type error in <"
-
-  gtVal :: Value -> Value -> Env Simulator
-  gtVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 > v2))
-  gtVal _ _ = return $ Sad "Type error in >"
-
-  lteVal :: Value -> Value -> Env Simulator
-  lteVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 <= v2))
-  lteVal _ _ = return $ Sad "Type error in <="
-
-  gteVal :: Value -> Value -> Env Simulator
-  gteVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 >= v2))
-  gteVal _ _ = return $ Sad "Type error in >="
-
-  eqVal :: Value -> Value -> Env Simulator
-  eqVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal (StringVal v1) (StringVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal v1 v2 = return $ Sad $ "Type error in ==: cannot compare " ++ show v1 ++ " and " ++ show v2
-
-  neqVal :: Value -> Value -> Env Simulator
-  neqVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal (StringVal v1) (StringVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal v1 v2 = return $ Sad $ "Type error in !=: cannot compare " ++ show v1 ++ " and " ++ show v2
-
-  andVal :: Value -> Value -> Env Simulator
-  andVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 && v2))
-  andVal _ _ = return $ Sad "Type error in &&"
-
-  orVal :: Value -> Value -> Env Simulator
-  orVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 || v2))
-  orVal _ _ = return $ Sad "Type error in ||"
-
-  notVal :: Value -> Env Simulator
-  notVal (BoolVal v) = return $ Happy (BoolVal (not v))
-  notVal _ = return $ Sad "Type error in !"
 
 infixl 1 ~
 
@@ -136,12 +23,12 @@ prog =
 
 main :: IO ()
 main = do
-  let out = reduceFully prog (Simulator M.empty [] [])
+  let out = reduceFully machineOps prog emptyMachine
   print out
   putStrLn "-----------------------------"
-  let out2 = reduceFully Progs.prog (Simulator M.empty [] [])
+  let out2 = reduceFully machineOps Progs.prog emptyMachine
   print out2
   putStrLn "-----------------------------"
   putStrLn "Testing booleans and comparisons:"
-  let out3 = reduceFully Progs.prog3 (Simulator M.empty [] [])
+  let out3 = reduceFully machineOps Progs.prog3 emptyMachine
   print out3

--- a/test/SmallSpec.hs
+++ b/test/SmallSpec.hs
@@ -1,183 +1,97 @@
-{-# LANGUAGE ConstrainedClassMethods #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
-
 module SmallSpec (spec) where
 
-import qualified Control.Monad.State as S
 import qualified Data.Map as M
-import Small
-import Term
+import MachineState (MachineState (..), emptyMachine, machineOps)
+import Small (reduceFully)
+import Term (BinaryOp (..), Term (..))
 import Test.Hspec
 import Value (Value (..))
-
--- A mock machine for testing
-data MockMachine = MockMachine {getMem :: M.Map String Value, getInput :: [Value], getOutput :: [Value]} deriving (Show, Eq)
-
-instance Machine MockMachine where
-  type V MockMachine = Value
-
-  getVar x = do
-    m <- S.get
-    case M.lookup x (getMem m) of
-      Just v -> return $ Happy v
-      Nothing -> return $ Sad "variable not found"
-
-  setVar x v = do
-    m <- S.get
-    S.put (m {getMem = M.insert x v (getMem m)})
-    return $ Happy v
-
-  inputVal = do
-    m <- S.get
-    case getInput m of
-      (i : is) -> do
-        S.put (m {getInput = is})
-        return $ Happy i
-      [] -> return $ Sad "end of input"
-
-  outputVal v = do
-    m <- S.get
-    S.put (m {getOutput = getOutput m ++ [v]})
-    return $ Happy v
-
-  subVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 - v2))
-  subVal _ _ = return $ Sad "Type error in subtraction"
-
-  addVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 + v2))
-  addVal _ _ = return $ Sad "Type error in addition"
-
-  mulVal (IntVal v1) (IntVal v2) = return $ Happy (IntVal (v1 * v2))
-  mulVal _ _ = return $ Sad "Type error in multiplication"
-
-  divVal (IntVal v1) (IntVal v2) =
-    if v2 == 0
-      then return $ Sad "Cannot divide by 0"
-      else return $ Happy (IntVal (v1 `div` v2)) -- I don't want the actual interpreter to crash
-  divVal _ _ = return $ Sad "Type error in division"
-
-  modVal (IntVal v1) (IntVal v2) =
-    if v2 == 0
-      then return $ Sad "Cannot mod by 0"
-      else return $ Happy (IntVal (v1 `mod` v2)) -- I don't want the actual interpreter to crash
-  modVal _ _ = return $ Sad "Type error in modulus"
-
-  ltVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 < v2))
-  ltVal _ _ = return $ Sad "Type error in <"
-
-  gtVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 > v2))
-  gtVal _ _ = return $ Sad "Type error in >"
-
-  lteVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 <= v2))
-  lteVal _ _ = return $ Sad "Type error in <="
-
-  gteVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 >= v2))
-  gteVal _ _ = return $ Sad "Type error in >="
-
-  eqVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal (StringVal v1) (StringVal v2) = return $ Happy (BoolVal (v1 == v2))
-  eqVal _ _ = return $ Sad "Type error in =="
-
-  neqVal (IntVal v1) (IntVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal (StringVal v1) (StringVal v2) = return $ Happy (BoolVal (v1 /= v2))
-  neqVal _ _ = return $ Sad "Type error in !="
-
-  andVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 && v2))
-  andVal _ _ = return $ Sad "Type error in &&"
-
-  orVal (BoolVal v1) (BoolVal v2) = return $ Happy (BoolVal (v1 || v2))
-  orVal _ _ = return $ Sad "Type error in ||"
-
-  notVal (BoolVal v) = return $ Happy (BoolVal (not v))
-  notVal _ = return $ Sad "Type error in !"
-
-  selectValue (BoolVal True) c _ = c
-  selectValue (BoolVal False) _ t = t
-  selectValue (IntVal n) c t = if n /= 0 then c else t
-  selectValue (StringVal s) c t = if not (null s) then c else t
 
 spec :: Spec
 spec = do
   describe "reduceFully" $ do
-    let initialMachine = MockMachine {getMem = M.empty, getInput = [], getOutput = []}
+    let initialMachine = emptyMachine
 
     it "reduces an integer literal" $ do
       let term = Literal 10
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 10), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 10), initialMachine)
 
     it "reduces a string literal" $ do
       let term = StringLiteral "hello"
-      reduceFully term initialMachine `shouldBe` (Right (StringVal "hello"), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (StringVal "hello"), initialMachine)
 
     it "reduces a variable" $ do
       let term = Var "x"
-      let machine = initialMachine {getMem = M.fromList [("x", IntVal 5)]}
-      reduceFully term machine `shouldBe` (Right (IntVal 5), machine)
+      let machine = initialMachine {machineMemory = M.fromList [("x", IntVal 5)]}
+      reduceFully machineOps term machine `shouldBe` (Right (IntVal 5), machine)
 
     it "reduces a let expression" $ do
       let term = Seq (Let "x" (Literal 5)) (Var "x")
-      let finalMachine = initialMachine {getMem = M.fromList [("x", IntVal 5)]}
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 5), finalMachine)
+      let finalMachine = initialMachine {machineMemory = M.fromList [("x", IntVal 5)]}
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 5), finalMachine)
 
     it "reduces a sequence" $ do
       let term = Seq (Let "x" (Literal 5)) (Var "x")
-      let finalMachine = initialMachine {getMem = M.fromList [("x", IntVal 5)]}
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 5), finalMachine)
+      let finalMachine = initialMachine {machineMemory = M.fromList [("x", IntVal 5)]}
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 5), finalMachine)
 
     it "reduces an if expression (then)" $ do
       let term = If (BoolLit True) (Literal 10) (Literal 20)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 10), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 10), initialMachine)
 
     it "reduces an if expression (else)" $ do
       let term = If (BoolLit False) (Literal 10) (Literal 20)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 20), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 20), initialMachine)
 
     it "reduces a while loop" $ do
       let term = Seq (Let "x" (Literal 3)) (While (Var "x") (Let "x" (BinaryOps Sub (Var "x") (Literal 1))))
-      let finalMachine = initialMachine {getMem = M.fromList [("x", IntVal 0)]}
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 0), finalMachine)
+      let finalMachine = initialMachine {machineMemory = M.fromList [("x", IntVal 0)]}
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 0), finalMachine)
 
     it "reduces read and write" $ do
       let term = Seq (Read "x") (Write (Var "x"))
-      let machine = initialMachine {getInput = [IntVal 42]}
-      let finalMachine = machine {getMem = M.fromList [("x", IntVal 42)], getOutput = [IntVal 42], getInput = []}
-      reduceFully term machine `shouldBe` (Right (IntVal 42), finalMachine)
+      let machine = initialMachine {machineInputs = [IntVal 42]}
+      let finalMachine =
+            machine
+              { machineMemory = M.fromList [("x", IntVal 42)],
+                machineOutputs = [IntVal 42],
+                machineInputs = []
+              }
+      reduceFully machineOps term machine `shouldBe` (Right (IntVal 42), finalMachine)
 
     it "reduces subtraction" $ do
       let term = BinaryOps Sub (Literal 10) (Literal 3)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 7), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 7), initialMachine)
 
     it "reduces addition" $ do
       let term = BinaryOps Add (Literal 10) (Literal 3)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 13), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 13), initialMachine)
 
     it "reduces multiplication" $ do
       let term = BinaryOps Mul (Literal 10) (Literal 3)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 30), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 30), initialMachine)
 
     it "reduces division - nonzero denominator case" $ do
       let term = BinaryOps Div (Literal 12) (Literal 3)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 4), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 4), initialMachine)
 
     it "reduces division - zero denominator case" $ do
       let term = BinaryOps Div (Literal 12) (Literal 0)
-      reduceFully term initialMachine `shouldBe` (Left "Cannot divide by 0", initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Left "Cannot divide by 0", initialMachine)
 
     it "reduces modulus - nonzero denominator case" $ do
       let term = BinaryOps Mod (Literal 12) (Literal 3)
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 0), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 0), initialMachine)
 
     it "reduces modulus - zero denominator case" $ do
       let term = BinaryOps Mod (Literal 12) (Literal 0)
-      reduceFully term initialMachine `shouldBe` (Left "Cannot mod by 0", initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Left "Cannot mod by 0", initialMachine)
 
     it "reduces skip" $ do
       let term = Skip
-      reduceFully term initialMachine `shouldBe` (Right (IntVal 0), initialMachine)
+      reduceFully machineOps term initialMachine `shouldBe` (Right (IntVal 0), initialMachine)
 
     it "returns a Sad result for a type error" $ do
       let term = BinaryOps Sub (Literal 10) (StringLiteral "hello")
-      let (result, _) = reduceFully term initialMachine
+      let (result, _) = reduceFully machineOps term initialMachine
       result `shouldBe` Left "Type error in subtraction"


### PR DESCRIPTION
I wasn't happy with how we:  
- Had a tightly coupled machine.  
- Could not easily add a type checker.  
- Had code duplication.  

So, scouring the deep dark corners of the internet (aka skimming category theory blogs), I discovered [Catamorphisms](https://en.wikipedia.org/wiki/Catamorphism). Don’t click that link yet — it’s full of scary math words I, frankly, still don’t fully understand.  

---

## You already know catamorphisms

Take a list:  

```haskell
[1, 2, 3, 4]
```

You’ve used foldr on it before, right? Congrats — you’ve been using catamorphisms all along. Your imposter syndrome can take a break.

Here’s the trick:

- Replace every : (cons) with your function
- Replace [] (nil) with your base value

```haskell
[1, 2, 3] = 1 : 2 : 3 : []
          = 1 + 2 + 3 + 0
          = 6
```

That’s all a catamorphism is: systematically replacing constructors.

## Trees work the same way

Example:
```haskell
-- Old way: recursion baked in
data Tree a = Leaf a | Branch (Tree a) (Tree a)

-- New way: recursion factored out
data TreeF a r = LeafF a | BranchF r r
  deriving Functor
```

Now, instead of hand-writing recursion for every function, we just write the "what to do at one node" logic:
```haskell
sumTree = cata sumAlg
  where
    sumAlg (LeafF n) = n
    sumAlg (BranchF l r) = l + r

countNodes = cata countAlg
  where
    countAlg (LeafF _) = 1
    countAlg (BranchF l r) = 1 + l + r

maxDepth = cata depthAlg
  where
    depthAlg (LeafF _) = 0
    depthAlg (BranchF l r) = 1 + max l r
```

## One more: Natural numbers
Same pattern works on naturals:
```haskell
data Nat = Zero | Succ Nat
data NatF r = ZeroF | SuccF r
```

Convert to Int:
```haskell
toInt = cata alg
  where
    alg ZeroF     = 0
    alg (SuccF n) = n + 1
```

Even test:
```haskell
isEven = cata alg
  where
    alg ZeroF     = True
    alg (SuccF b) = not b
```

Every recursive structure — lists, trees, ASTs, even numbers — can be folded this way.

## Now for our AST
Our AST is just a fancy tree. If we can fold lists, we can fold ASTs.

The trick is to split Term into two:
- Term: the recursive structure (what we had before)
- TermF: the same, but with recursion replaced by a type parameter

Old:
```haskell
data Term = If Term Term Term | BinaryOps Add Term Term | ...
```

New:
```haskell
data TermF a = IfF a a a | BinaryOpsF Add a a | ...
```

And two helpers:
```haskell
projectTerm :: Term -> TermF Term  -- peel off one layer
embedTerm   :: TermF Term -> Term  -- put it back
```

Consider an example
```haskell
projectTerm (If (BoolLit True) (Literal 1) (Literal 2))
== IfF (BoolLit True) (Literal 1) (Literal 2)
```

And now our interpreter is just:
```haskell
interpret = cata alg
  where
    alg (LiteralF n) = n
    alg (BinaryOpsF Add x y) = x + y
    alg (IfF cond t e) = if cond then t else e
```

Want a type checker?
```haskell
typecheck = cata alg
  where
    alg (LiteralF _) = IntType
    alg (BinaryOpsF Add t1 t2) =
      if t1 == IntType && t2 == IntType then IntType
      else TypeError "Math is hard"
```

Same fold, different algebra. That’s the beauty: we never reimplement recursion.

## Paramorphisms
One wrinkle: sometimes we need both the subtree’s result and the subtree itself (e.g. our small-step semantics). That’s when we use a paramorphism (para) instead of a catamorphism (cata).

Example for binary ops:
```haskell
binaryStep rebuild (_leftTerm, evalLeft) (rightTerm, evalRight) apply = do
  leftResult <- evalLeft
  case leftResult of
    Continue nextLeft -> pure (Continue (rebuild nextLeft rightTerm))
    -- need original rightTerm here
```

So: cata gives you results, para gives you results + the original.

## The Fix point rabbit hole
If you want to go full category theory, you can define recursion with Fix:

```haskell
newtype Fix f = Fix (f (Fix f))
type Term = Fix TermF
```

Theoretically nice: you get project/embed for free, and can use some libraries designed to work over this.
But in practice, code becomes less ergonomic:
```haskell
-- Wanted:
While (Lt (Var "x") (Literal 10)) (BinaryOps Add (Var "x") (Literal 1))

-- With Fix:
Fix (WhileF 
  (Fix (LtF (Fix (VarF "x")) (Fix (LiteralF 10))))
  (Fix (BinaryOpsF Add (Fix (VarF "x")) (Fix (LiteralF 1)))))
```

## The end

Is it worth it? I think so. Do I understand all the category theory behind it? Absolutely not. But hey, it works and solves our problems. Remember. It's just a generic walk over your trees; no more, no less. I just wish I knew about it before writing my proposal... I've gone too far to refactor that one.

Closes #30, closes #31.
