### PR TITLE
Fixing Closure Semantics and Cleaning Up Some Code

### DIFF
--- a/FunLexer.hs
+++ b/FunLexer.hs
@@ -28,7 +28,8 @@ keywords =
       "try",
       "catch",
       "true",
-      "false" -- force boolean literals to be tokens in the parser
+      "false",
+      "capture"
     ]
 
 lexer :: [Char] -> [Token]

--- a/FunSyntax.hs
+++ b/FunSyntax.hs
@@ -16,6 +16,8 @@ import FunLexer (Token (Ident, Keyword, Num, StringLiteralLexed, Symbol), lexer)
 import ParserCombinators (Parser, Result, oneof, opt, rpt, rptDropSep, satisfy, token)
 import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Term (..), UnaryOp (..))
 
+-- Add Capture to export list if needed
+
 -- data Term
 --   = Assign String Term
 --   | BinaryOp String Term Term
@@ -247,8 +249,15 @@ printStmt = do
   expr <- term
   return $ Write expr
 
+-- Parser for 'capture x' statement
+captureStmt :: Parser Token Term
+captureStmt = do
+  _ <- keyword "capture"
+  name <- ident
+  return $ Capture name
+
 unaryExp :: Parser Token Term
-unaryExp = oneof [assign, ifExpr, block, funDef, minus, num, string, bool, tuple, dictionary, bracketSet, bracketAccess, tryCatch, parens, varDef, funCall, varRef, whileTerm, printStmt]
+unaryExp = oneof [captureStmt, assign, ifExpr, block, funDef, minus, num, string, bool, tuple, dictionary, bracketSet, bracketAccess, tryCatch, parens, varDef, funCall, varRef, whileTerm, printStmt]
 
 ----------- prog ----------
 

--- a/Term.hs
+++ b/Term.hs
@@ -31,6 +31,7 @@ data Term
   | SetBracket String Term Term
   | Fun [String] Term
   | ApplyFun Term [Term]
+  | Capture String
   | BreakSignal
   | ContinueSignal
   deriving (Eq, Show)

--- a/Value.hs
+++ b/Value.hs
@@ -26,12 +26,12 @@ data Value
   deriving (Eq, Show)
 
 valueToDebugString :: Value -> String
-valueToDebugString(IntVal _) = "Integer"
-valueToDebugString(BoolVal _) = "Boolean"
-valueToDebugString(StringVal _) = "String"
-valueToDebugString(Tuple _) = "Tuple"
-valueToDebugString(ClosureVal {}) = "Function"
-valueToDebugString(Dictionary _) = "Dictionary"
+valueToDebugString (IntVal _) = "Integer"
+valueToDebugString (BoolVal _) = "Boolean"
+valueToDebugString (StringVal _) = "String"
+valueToDebugString (Tuple _) = "Tuple"
+valueToDebugString (ClosureVal {}) = "Function"
+valueToDebugString (Dictionary _) = "Dictionary"
 
 valueToInt :: Value -> Either String Integer
 valueToInt (IntVal n) = Right n

--- a/test/FunSyntaxSpec.hs
+++ b/test/FunSyntaxSpec.hs
@@ -204,3 +204,25 @@ spec = do
         Left err -> fail $ "Parse error: " ++ err
         Right (ast, _) -> do
           ast `shouldSatisfy` const True
+
+  describe "Variable Capture with Closures" $ do
+    it "correctly captures variables in nested functions" $ do
+      let program =
+            unlines
+              [ "fun outer() {",
+                "    var x = 5",
+                "    fun inner() {",
+                "       capture x",
+                "       x + 10",
+                "    }",
+                "    inner",
+                "}",
+                "result = outer()",
+                "result()"
+              ]
+      let result = parseString program
+      case result of
+        Left err -> fail $ "Parse error: " ++ err
+        Right (ast, _) -> do
+          print ast
+          ast `shouldSatisfy` const True


### PR DESCRIPTION
Working with @mercutio-22 on above

Current closure semantics don't allow for writing to values outside of function and also interfere with semantics for nesting functions, etc. New implementation only copies values specified with `capture` keyword. Still needs lexical scoping for full support.