### PR TITLE
fix(scope): do not look in parent scope for variable for lexical scoping

### DIFF
--- a/Scope.hs
+++ b/Scope.hs
@@ -15,13 +15,10 @@ data Scope = Scope (M.Map String Value) (Maybe Scope)
   deriving (Eq, Show)
 
 lookupScope :: String -> Scope -> Maybe Value
-lookupScope name (Scope m parent) =
+lookupScope name (Scope m _) =
   case M.lookup name m of
     Just v -> Just v
-    Nothing ->
-      case parent of
-        Just p -> lookupScope name p -- Look in parent scope.
-        Nothing -> Nothing
+    Nothing -> Nothing -- Do not look in parent scopes.
 
 insertScope :: String -> Value -> Scope -> Scope
 insertScope name val (Scope m parent) = Scope (M.insert name val m) parent -- Insert into inner scope.

--- a/test/SmallSpec.hs
+++ b/test/SmallSpec.hs
@@ -689,6 +689,12 @@ spec = do
       let machine = initialMachine {getMem = scopeFromList [("x", IntVal 1)]}
       reduceFully term initialMachine `shouldBe` (Right (IntVal 5), machine)
 
+    it "errors on undefined variable in function scope" $ do
+      let f1 = Fun [] (Seq (Let "y" (Literal 3)) (ApplyFun (Var "f") []))
+      let term = Seq (Let "f" (Fun [] (Write (Var "y")))) (ApplyFun f1 []) -- f defined outside of f1.
+      let machine = initialMachine {getMem = scopeFromList [("f", ClosureVal [] (Write (Var "y")) [])]}
+      reduceFully term initialMachine `shouldBe` (Left "variable not found", machine) -- Does not capture y = 3.
+
     -- Comparison Operations Tests
     it "reduces less than comparison" $ do
       let term = BinaryOps Lt (Literal 5) (Literal 10)


### PR DESCRIPTION
No longer looks in the parent scope to find variables, so only captured variables are checked when calling functions.