### PR TITLE
Added QOL test cases, 

### DIFF
--- a/FunSyntax.hs
+++ b/FunSyntax.hs
@@ -35,7 +35,7 @@ ident = satisfy $ \case
 -- Parse an identifier you can *bind* (not a reserved word).
 pBinder :: Parser String
 pBinder = do
-  x <- ident  
+  x <- ident
   if x `S.member` keywords
     then fail ("reserved word in binder: " <> x)
     else pure x
@@ -276,11 +276,14 @@ eqLevel = do
   try (symbol "=" *> fail "Use '==' for equality. Bindings must use 'let x = ...'") <|> pure ()
   -- Then parse the real comparison operators as usual:
   rest lhs
- where
-  rest lhs = (do op <- choice (map (symbol . fst) cmpOps)
-                 rhs <- addLevel
-                 rest (Bin (toOp op) lhs rhs))
-         <|> pure lhs
+  where
+    rest lhs =
+      ( do
+          op <- choice (map (symbol . fst) cmpOps)
+          rhs <- addLevel
+          rest (Bin (toOp op) lhs rhs)
+      )
+        <|> pure lhs
 
 ----------- prog ----------
 

--- a/test/SyntaxDXSpec.hs
+++ b/test/SyntaxDXSpec.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module SyntaxDXSpec where
 
+import ParserCombinators (parseTerm)
+import Sprintf (renderError)
 import Test.Hspec
-import ParserCombinators (parseTerm)  
-import Sprintf (renderError)          
 
 spec :: Spec
 spec = do
@@ -25,7 +26,7 @@ spec = do
   describe "bare equals in expressions" $ do
     it "rejects lone '='" $ do
       case parseTerm "1 = 2" of
-        Left e  -> renderError e `shouldContain` "Use '==' for equality"
+        Left e -> renderError e `shouldContain` "Use '==' for equality"
         Right _ -> expectationFailure "expected an error"
 
   describe "keywords cannot be bound" $ do


### PR DESCRIPTION
Added test cases that lock in my DX quality of life decisions. Also added helpful error text for lone = in expressions
to catch the common = vs == slip with a precise message.