### PR TITLE
Reference (lvalue) parsing

### DIFF
--- a/FunSyntax.hs
+++ b/FunSyntax.hs
@@ -12,7 +12,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
 import FunLexer (Token (Ident, Keyword, Num, StringLiteralLexed, Symbol), lexer)
 import ParserCombinators (Parser, Result, oneof, opt, rpt, rptDropSep, satisfy, token, (<|>))
-import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Ref (..), Term (..), UnaryOp (..))
+import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Term (..), UnaryOp (..))
 
 -- succeed if the next token is the given symbol
 symbol :: String -> Parser Token ()
@@ -55,7 +55,7 @@ term = [t | t <- refassign <|> binaryExp precedence, _ <- opt $ symbol ";"]
 refassign :: Parser Token Term
 refassign = [Let ref expr | ref <- reference, _ <- symbol "=", expr <- term]
 
-reference :: Parser Token Ref
+reference :: Parser Token Term
 reference = do
   -- very similar to chainl1
   x <- OnlyStr <$> ident

--- a/Progs.hs
+++ b/Progs.hs
@@ -9,7 +9,7 @@ infixl 1 ~
 
 infixl 9 <=>
 
-(<=>) :: Ref -> Term -> Term
+(<=>) :: Term -> Term -> Term
 (<=>) = Let
 
 prog :: Term

--- a/Small.hs
+++ b/Small.hs
@@ -11,7 +11,7 @@ import qualified Control.Monad.State as S
 import Data.Either
 import qualified Data.Map as M
 import Debug.Trace (trace)
-import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Ref (..), Term (..), UnaryOp (..))
+import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Term (..), UnaryOp (..))
 import Value (Value (..), valueToInt, valueToTuple)
 
 ----- The Machine type class -----
@@ -118,6 +118,11 @@ reduce_ (Var x) = do
   case x of
     OnlyStr s -> getVar s
     Bracket ref term -> return $ Continue (Retrieve (Var ref) term)
+    _ -> return $ Sad (Type, "Operand of Var must be a reference")
+reduce_ (OnlyStr s) =
+  return $ Continue $ Var (OnlyStr s)
+reduce_ (Bracket t1 t2) =
+  return $ Continue $ Var (Bracket t1 t2)
 reduce_ (Retrieve t1 t2) = do
   premise
     (reduce t1)
@@ -135,6 +140,7 @@ reduce_ (Let x t) = do
         (Let x)
         (setVar s)
     Bracket ref term -> return $ Continue $ Let ref (Merge (Var ref) term t)
+    _ -> return $ Sad (Type, "Left-hand side of Let must be reference")
 reduce_ (Merge t1 t2 t3) = do
   premise
     (reduce t1)

--- a/Term.hs
+++ b/Term.hs
@@ -1,4 +1,4 @@
-module Term (Ref (..), Term (..), BinaryOp (..), UnaryOp (..), ErrorKind (..), ErrorKindOrAny (..)) where
+module Term (Term (..), BinaryOp (..), UnaryOp (..), ErrorKind (..), ErrorKindOrAny (..)) where
 
 data BinaryOp = Add | Sub | Mul | Div | Mod | Lt | Gt | Lte | Gte | Eq | Neq | And | Or | Pow | Xor
   deriving (Eq, Show)
@@ -10,12 +10,10 @@ data ErrorKind = Arithmetic | Type | Input | VariableNotFound | Arguments derivi
 
 data ErrorKindOrAny = Specific ErrorKind | Any deriving (Eq, Show)
 
-data Ref = OnlyStr String | Bracket Ref Term deriving (Eq, Show)
-
 data Term
   = If Term Term Term
   | Try Term ErrorKindOrAny Term
-  | Let Ref Term
+  | Let Term Term
   | Literal Integer
   | StringLiteral String
   | Read String
@@ -23,7 +21,9 @@ data Term
   | Skip
   | BinaryOps BinaryOp Term Term
   | UnaryOps UnaryOp Term
-  | Var Ref
+  | Var Term
+  | OnlyStr String
+  | Bracket Term Term
   | While Term Term
   | Write Term
   | BoolLit Bool

--- a/sim/Main.hs
+++ b/sim/Main.hs
@@ -11,7 +11,7 @@ import qualified Data.Map as M
 import qualified Progs
 import Scope (Scope (..), emptyScope, getAllBindings, insertScope, lookupScope)
 import Small (Env, Error, Machine (..), Result (..), reduceFully)
-import Term (ErrorKind (..), Ref (..), Term (..))
+import Term (ErrorKind (..), Term (..))
 import Value (Value (..))
 
 data Simulator = Simulator Scope [Value] [Value] deriving (Eq, Show)
@@ -249,7 +249,7 @@ infixl 1 ~
 
 infixl 9 <=>
 
-(<=>) :: Ref -> Term -> Term
+(<=>) :: Term -> Term -> Term
 (<=>) = Let
 
 prog :: Term

--- a/test/FunSyntaxSpec.hs
+++ b/test/FunSyntaxSpec.hs
@@ -5,7 +5,7 @@ module FunSyntaxSpec (spec) where
 import FunLexer (Token (..))
 import FunSyntax (parse, prog)
 import ParserCombinators (eof)
-import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Ref (..), Term (..))
+import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Term (..))
 import Test.Hspec
 
 -- Helper function to parse from a string


### PR DESCRIPTION
Parse references more idiomatically than before, using a technique similar to `chainl1`.

This PR also reintegrates the `Ref` datatype into `Term`. This removes the situation where those two datatypes were interdependent, which blocked certain improvements to the handling of Terms.

close #133 