### PR TITLE
Refactoring Small to use monad comprehensions and behave more like operational semantics

### DIFF
--- a/Decompile.hs
+++ b/Decompile.hs
@@ -35,6 +35,8 @@ decompile = cata go
       sprintf "Bracket (%s) (%s)" [t1, t2]
     go (WhileF cond body) =
       sprintf "While (%s) (%s)" [cond, body]
+    go (ForF var start end body) =
+      sprintf "For %s (%s) (%s) (%s)" [var, start, end, body]
     go (WriteF t) =
       sprintf "Write (%s)" [t]
     go (BoolLitF b) =

--- a/FunSyntax.hs
+++ b/FunSyntax.hs
@@ -214,6 +214,9 @@ varDef =
 whileTerm :: Parser Token Term
 whileTerm = [While cond body | _ <- keyword "while", cond <- term, body <- term]
 
+forTerm :: Parser Token Term
+forTerm = [For var start end body | _ <- keyword "for", var <- ident, start <- term, end <- term, body <- term]
+
 tryCatch :: Parser Token Term
 tryCatch =
   [ Try tryBranch (errorType err) catchBranch
@@ -250,7 +253,7 @@ printStmt =
   ]
 
 unaryExp :: Parser Token Term
-unaryExp = oneof [ifExpr, block, funDef, minus, bitnot, preIncrement, preDecrement, num, string, bool, tuple, dictionary, tryCatch, parens, varDef, funCall, postIncrement, postDecrement, varRef, whileTerm, printStmt]
+unaryExp = oneof [ifExpr, block, funDef, minus, bitnot, preIncrement, preDecrement, num, string, bool, tuple, dictionary, tryCatch, parens, varDef, funCall, postIncrement, postDecrement, varRef, whileTerm, forTerm, printStmt]
 
 ----------- prog ----------
 

--- a/Small.hs
+++ b/Small.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Small (reduceFully, Machine (..), Result (..), Error, Env) where
 
-import Control.Arrow ((>>>))
+-- import Data.Either
+
+import Control.Applicative
+import Control.Monad
 import qualified Control.Monad.State as S
-import Data.Either
 import qualified Data.Map as M
 import Debug.Trace (trace)
 import Term (BinaryOp (..), ErrorKind (..), ErrorKindOrAny (..), Term (..), UnaryOp (..))
-import Value (Value (..), valueToInt, valueToTuple)
+import Value (Value (..))
 
 ----- The Machine type class -----
 
@@ -76,31 +79,9 @@ class Machine m where
   -- Control flow - selectValue uses boolean semantics
   selectValue :: V m -> Env m -> Env m -> Env m
 
------ The Result type -----
-
-type Error = (ErrorKind, String)
-
-data Result a
-  = Happy a -- produced an answer
-  | Continue Term -- need to keep going
-  | Sad Error -- error
-  deriving (Eq, Show)
-
------ The Env monad -----
-
 -- abstract semantics that glue micro-ops together
 
-type Env m = S.State m (Result (V m))
-
-premise :: Env m -> (Term -> Term) -> (V m -> Env m) -> Env m
-premise e l r = do
-  v <- e
-  case v of
-    Continue BreakSignal -> return $ Continue BreakSignal
-    Continue ContinueSignal -> return $ Continue ContinueSignal
-    Continue t' -> return $ Continue (l t')
-    Happy n -> r n
-    Sad _ -> return v
+type Error = (ErrorKind, String)
 
 -- Helper for try-catch statement
 errorShouldBeCaught :: ErrorKind -> ErrorKindOrAny -> Bool
@@ -109,113 +90,485 @@ errorShouldBeCaught resultErrorKind (Specific catchableErrorKind) = resultErrorK
 
 ------ Small-step reduction ------
 
-reduce_ :: (Machine m, Show m, V m ~ Value) => Term -> Env m
-reduce_ (Literal n) =
-  return $ Happy $ IntVal n
-reduce_ (StringLiteral s) =
-  return $ Happy $ StringVal s
-reduce_ (Var x) =
-  case x of
-    OnlyStr s -> getVar s
-    Bracket ref term -> return $ Continue (Retrieve (Var ref) term)
-    _ -> return $ Sad (Type, "Operand of Var must be a reference")
-reduce_ (OnlyStr s) =
-  return $ Continue $ Var (OnlyStr s)
-reduce_ (Bracket t1 t2) =
-  return $ Continue $ Var (Bracket t1 t2)
-reduce_ (Retrieve t1 t2) =
-  premise
-    (reduce t1)
-    (`Retrieve` t2)
-    ( getBracketValue
-        >>> premise
-          (reduce t2)
-          (Retrieve t1)
+data Result a
+  = Happy a -- produced an answer
+  | Continue Term -- need to keep going
+  | Sad Error -- error
+  deriving (Eq, Show)
+
+type Env m = S.State m (Result (V m))
+
+-- Polymorphic reduction monad: carries state + rule-applicability (Maybe)
+newtype Reduction m a = Reduction {runRed :: S.StateT m Maybe a}
+  deriving (Functor, Applicative, Monad, Alternative, MonadPlus, S.MonadState m, MonadFail)
+
+-- one small step of a subterm; fails unless it was Continue
+step :: (Machine m, Show m, V m ~ Value) => Term -> Reduction m Term
+-- step t = [ t' | Continue t' <- reduce t ]
+step t =
+  asum
+    [ [BreakSignal | Continue BreakSignal <- reduce t],
+      [ContinueSignal | Continue ContinueSignal <- reduce t],
+      [t' | Continue t' <- reduce t]
+    ]
+
+-- -- extract a signal; fails unless it was BreakSignal or ContinueSignal
+-- signal :: (Machine m, Show m, V m ~ Value) => Term -> Reduction m Term
+-- signal t = asum
+--   [ [ BreakSignal   | BreakSignal   <- pure t ]
+--   , [ ContinueSignal | ContinueSignal <- pure t ]
+--   ]
+
+-- extract a value; fails unless it was Happy
+val :: (Machine m, Show m, V m ~ Value) => Term -> Reduction m (V m)
+val t = [v | Happy v <- reduce t]
+
+-- extract an error; fails unless it was Sad
+fault :: (Machine m, Show m, V m ~ Value) => Rule m
+fault t = [Sad e | Sad e <- reduce t]
+
+-- run an Env m inside Reduction m (syntactic sugar for liftEnv)
+envR :: Env m -> Reduction m (Result (V m))
+envR e = Reduction $ S.StateT $ \s ->
+  let (r, s') = S.runState e s in Just (r, s')
+
+-- pick between branches using your fixed selectValue, but stay in Reduction
+selectR ::
+  (Machine m, V m ~ Value) =>
+  V m ->
+  Term ->
+  Term ->
+  Reduction m (Result (V m))
+selectR cond tThen tElse =
+  envR
+    ( selectValue
+        cond
+        (return (Continue tThen)) -- :: Env m
+        (return (Continue tElse)) -- :: Env m
     )
-reduce_ (Let x t) =
-  case x of
-    OnlyStr s ->
-      premise
-        (reduce t)
-        (Let x)
-        (setVar s)
-    Bracket ref term -> return $ Continue $ Let ref (Merge (Var ref) term t)
-    _ -> return $ Sad (Type, "Left-hand side of Let must be reference")
-reduce_ (Merge t1 t2 t3) =
-  premise
-    (reduce t1)
-    (\t1' -> Merge t1' t2 t3)
-    ( \v1 ->
-        premise
-          (reduce t2)
-          (\t2' -> Merge t1 t2' t3)
-          ( setBracketValue v1
-              >>> premise
-                (reduce t3)
-                (Merge t1 t2)
-          )
-    )
-reduce_ (Seq t1 t2) = do
-  res1 <- reduce t1 -- run t1 normally
-  case res1 of
-    Continue BreakSignal -> return $ Continue BreakSignal
-    Continue ContinueSignal -> return $ Continue ContinueSignal
-    Continue t' -> return $ Continue (Seq t' t2)
-    Happy _ -> reduce t2 -- normal: continue with t2
-    Sad msg -> return $ Sad msg
-reduce_ (If cond tThen tElse) =
-  premise
-    (reduce cond)
-    (\cond' -> If cond' tThen tElse)
-    (\v -> selectValue v (return $ Continue tThen) (return $ Continue tElse))
-reduce_ (Try tTry catchableErrorKindOrAny tCatch) = do
-  vTry <- reduce tTry
-  case vTry of
-    Continue tTry' -> return $ Continue (Try tTry' catchableErrorKindOrAny tCatch)
-    Happy n -> return $ Happy n
-    Sad (resultErrorKind, _) | errorShouldBeCaught resultErrorKind catchableErrorKindOrAny -> return $ Continue tCatch
-    Sad _ -> return vTry
-reduce_ (While cond body) =
-  premise
-    (reduce cond)
-    (`While` body)
-    ( \v ->
-        selectValue
-          v
-          ( do
-              res <- reduce body
-              case res of
-                Continue BreakSignal -> return $ Happy (IntVal 0)
-                Continue ContinueSignal -> return $ Continue (While cond body)
-                Continue t -> return $ Continue (Seq t (While cond body))
-                Happy _ -> return $ Continue (While cond body)
-                Sad msg -> return $ Sad msg
-          )
-          ( return $ Continue Skip
-          )
-    )
-reduce_ (Read x) =
-  premise
-    inputVal
-    id
-    (setVar x)
-reduce_ (Write t) =
-  premise
-    (reduce t)
-    Write
-    outputVal
-reduce_ Skip =
-  return $ Happy (IntVal 0)
-reduce_ (BinaryOps op t1 t2) =
-  premise
-    (reduce t1)
-    (\t1' -> BinaryOps op t1' t2)
-    ( \v1 ->
-        premise
-          (reduce t2)
-          (BinaryOps op (Literal $ fromRight (-1) (valueToInt v1)))
-          (applyBinaryOp op v1)
-    )
+
+getTruthinessR ::
+  (Machine m, V m ~ Value) =>
+  V m ->
+  Reduction m Bool
+getTruthinessR cond = do
+  r <-
+    envR
+      ( selectValue
+          cond
+          (return (Happy (BoolVal True)))
+          (return (Happy (BoolVal False)))
+      )
+  case r of
+    Happy (BoolVal b) -> pure b
+    _ -> error "getTruthinessR: selectValue did not return BoolVal"
+
+-- A small-step rule returns a Step
+type Rule m = Term -> Reduction m (Result (V m))
+
+tryRules :: (Machine m, Show m, V m ~ Value) => [Rule m] -> Rule m
+tryRules rules t = asum [rule t | rule <- rules]
+
+reduce_ :: (Machine m, Show m, V m ~ Value) => Rule m
+reduce_ = tryRules rules
+  where
+    rules =
+      [ -- rules go here
+        reduceLiteral,
+        reduceVar,
+        reduceRetrieve,
+        reduceLet,
+        reduceMerge,
+        reduceSeq,
+        reduceIf,
+        reduceTry,
+        reduceWhile,
+        reduceFor,
+        reduceRead,
+        reduceWrite,
+        reduceSkip,
+        reduceBinaryOps,
+        reduceUnaryOps,
+        reduceBreakContinue,
+        reduceFun,
+        reduceApplyFun,
+        reduceIncDec,
+        reduceTupleTerm,
+        reduceDictionary
+      ]
+
+reduceLiteral :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceLiteral t =
+  asum
+    [ [Happy (IntVal n) | Literal n <- pure t],
+      [Happy (StringVal s) | StringLiteral s <- pure t],
+      [Happy (BoolVal b) | BoolLit b <- pure t]
+    ]
+
+reduceIf :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceIf t =
+  asum
+    [ -- step the condition
+      [ Continue (If cond' tThen tElse)
+        | If cond tThen tElse <- pure t,
+          cond' <- step cond
+      ],
+      -- condition is a value: choose branch via selectValue
+      [ r
+        | If cond tThen tElse <- pure t,
+          v <- val cond,
+          r <- selectR v tThen tElse
+      ],
+      -- condition faults: propagate
+      [ e
+        | If cond _ _ <- pure t,
+          e <- fault cond
+      ]
+    ]
+
+reduceVar :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceVar t =
+  asum
+    [ -- plain variable lookup
+      [ r
+        | Var (OnlyStr s) <- pure t,
+          r <- envR (getVar s)
+      ],
+      -- bracket form desugars to a Retrieve step
+      [ Continue (Retrieve (Var ref) term)
+        | Var (Bracket ref term) <- pure t
+      ],
+      -- normalize lone OnlyStr / Bracket into a Var node
+      [Continue (Var (OnlyStr s)) | OnlyStr s <- pure t],
+      [Continue (Var (Bracket a b)) | Bracket a b <- pure t],
+      -- reference wrong type: error
+      [ Sad (Type, "Operand of Var must be a reference")
+        | Var _ <- pure t
+      ]
+    ]
+
+reduceRetrieve :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceRetrieve t =
+  asum
+    [ -- step t1
+      [ Continue (Retrieve t1' t2)
+        | Retrieve t1 t2 <- pure t,
+          t1' <- step t1
+      ],
+      -- t1 is a value: step t2
+      [ Continue (Retrieve t1 t2')
+        | Retrieve t1 t2 <- pure t,
+          _ <- val t1,
+          t2' <- step t2
+      ],
+      -- both t1 and t2 are values: perform getBracketValue
+      [ r
+        | Retrieve t1 t2 <- pure t,
+          v1 <- val t1,
+          v2 <- val t2,
+          r <- envR (getBracketValue v1 v2)
+      ],
+      -- fault in t1: propagate
+      [ e
+        | Retrieve t1 _ <- pure t,
+          e <- fault t1
+      ],
+      -- fault in t2: propagate
+      [ e
+        | Retrieve t1 t2 <- pure t,
+          _ <- val t1,
+          e <- fault t2
+      ]
+    ]
+
+reduceLet :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceLet t =
+  asum
+    [ -- step the RHS
+      [ Continue (Let ref rhs')
+        | Let ref rhs <- pure t,
+          rhs' <- step rhs
+      ],
+      -- LHS is a plain variable: perform setVar
+      [ r
+        | Let (OnlyStr s) rhs <- pure t,
+          v <- val rhs,
+          r <- envR (setVar s v)
+      ],
+      -- LHS is a bracketed reference: desugar to Merge
+      [ Continue (Let ref' (Merge (Var ref') bTerm rhs))
+        | Let (Bracket ref' bTerm) rhs <- pure t
+      ],
+      -- fault in RHS: propagate
+      [ e
+        | Let _ rhs <- pure t,
+          e <- fault rhs
+      ],
+      -- LHS wrong type: error
+      [ Sad (Type, "Left-hand side of Let must be reference")
+        | Let _ _ <- pure t
+      ]
+    ]
+
+reduceMerge :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceMerge t =
+  asum
+    [ -- step t1
+      [ Continue (Merge t1' t2 t3)
+        | Merge t1 t2 t3 <- pure t,
+          t1' <- step t1
+      ],
+      -- t1 is a value: step t2
+      [ Continue (Merge t1 t2' t3)
+        | Merge t1 t2 t3 <- pure t,
+          _ <- val t1,
+          t2' <- step t2
+      ],
+      -- t1 and t2 are values: step t3
+      [ Continue (Merge t1 t2 t3')
+        | Merge t1 t2 t3 <- pure t,
+          _ <- val t1,
+          _ <- val t2,
+          t3' <- step t3
+      ],
+      -- all three are values: perform setBracketValue
+      [ r
+        | Merge t1 t2 t3 <- pure t,
+          v1 <- val t1,
+          v2 <- val t2,
+          v3 <- val t3,
+          r <- envR (setBracketValue v1 v2 v3)
+      ],
+      -- fault in t1: propagate
+      [ e
+        | Merge t1 _ _ <- pure t,
+          e <- fault t1
+      ],
+      -- fault in t2: propagate
+      [ e
+        | Merge t1 t2 _ <- pure t,
+          _ <- val t1,
+          e <- fault t2
+      ],
+      -- fault in t3: propagate
+      [ e
+        | Merge t1 t2 t3 <- pure t,
+          _ <- val t1,
+          _ <- val t2,
+          e <- fault t3
+      ]
+    ]
+
+reduceSeq :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceSeq t =
+  asum
+    [ -- step t1 (signal-aware when t2 is a While)
+      [ res
+        | Seq t1 t2 <- pure t,
+          t1' <- step t1,
+          let res = case (t1', t2) of
+                -- left side signalled while we're sequencing into a loop on the right:
+                (BreakSignal, While _ _) -> Happy (IntVal 0) -- break: exit loop
+                (ContinueSignal, While c b) -> Continue (While c b) -- continue: next iter
+                -- otherwise: propagate signals normally
+                (BreakSignal, _) -> Continue BreakSignal
+                (ContinueSignal, _) -> Continue ContinueSignal
+                -- no signal: keep stepping the sequence
+                _ -> Continue (Seq t1' t2)
+      ],
+      -- t1 is done: continue with t2
+      [ Continue t2
+        | Seq t1 t2 <- pure t,
+          _ <- val t1
+      ],
+      -- fault in t1: propagate
+      [ e
+        | Seq t1 _ <- pure t,
+          e <- fault t1
+      ]
+    ]
+
+reduceTry :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceTry t =
+  asum
+    [ -- step tTry
+      [ Continue (Try tTry' catchableErrorKindOrAny tCatch)
+        | Try tTry catchableErrorKindOrAny tCatch <- pure t,
+          tTry' <- step tTry
+      ],
+      -- tTry is done: handle according to result
+      [ Happy vTry
+        | Try tTry _ _ <- pure t,
+          vTry <- val tTry
+      ],
+      -- tTry faulted: see if we catch
+      [ Continue tCatch
+        | Try tTry catchableErrorKindOrAny tCatch <- pure t,
+          Sad (resultErrorKind, _) <- fault tTry,
+          errorShouldBeCaught resultErrorKind catchableErrorKindOrAny
+      ],
+      -- tTry faulted: propagate
+      [ Sad e
+        | Try tTry catchableErrorKindOrAny _ <- pure t,
+          Sad e <- fault tTry,
+          let (resultErrorKind, _) = e,
+          not (errorShouldBeCaught resultErrorKind catchableErrorKindOrAny)
+      ]
+    ]
+
+reduceWhile :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceWhile t =
+  asum
+    [ -- step condition
+      [ Continue (While cond' body)
+        | While cond body <- pure t,
+          cond' <- step cond
+      ],
+      -- condition is a value and is false
+      [ Continue Skip
+        | While cond _ <- pure t,
+          condVal <- val cond,
+          truthiness <- getTruthinessR condVal,
+          not truthiness
+      ],
+      -- condition is a value and is true but body steps
+      [ res
+        | While cond body <- pure t,
+          condVal <- val cond,
+          truthiness <- getTruthinessR condVal,
+          truthiness,
+          body' <- step body,
+          let res = case body' of
+                BreakSignal -> Happy (IntVal 0)
+                ContinueSignal -> Continue (While cond body)
+                b -> Continue (Seq b (While cond body))
+      ],
+      -- condition is a value and it is true but body is value
+      [ Continue (While cond body)
+        | While cond body <- pure t,
+          condVal <- val cond,
+          truthiness <- getTruthinessR condVal,
+          truthiness,
+          _ <- val body
+      ],
+      -- fault in condition: propagate
+      [ e
+        | While cond _ <- pure t,
+          e <- fault cond
+      ],
+      -- fault in body: propagate
+      [ e
+        | While cond body <- pure t,
+          condVal <- val cond,
+          truthiness <- getTruthinessR condVal,
+          truthiness,
+          e <- fault body
+      ]
+    ]
+
+reduceFor :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceFor t =
+  asum
+    [ -- step start
+      [ Continue (For var start' end body)
+        | For var start end body <- pure t,
+          start' <- step start
+      ],
+      -- start is a value: step end
+      [ Continue (For var start end' body)
+        | For var start end body <- pure t,
+          _ <- val start,
+          end' <- step end
+      ],
+      -- both start and end are values: desugar to Let + While
+      [ Continue (Seq (Let (OnlyStr var) start) (While cond body'))
+        | For var start end body <- pure t,
+          _ <- val start,
+          IntVal iEnd <- val end,
+          let cond = BinaryOps Lt (Var (OnlyStr var)) (Literal iEnd),
+          let body' = Seq body (Let (OnlyStr var) (BinaryOps Add (Var (OnlyStr var)) (Literal 1)))
+      ],
+      -- fault in start: propagate
+      [ e
+        | For _ start _ _ <- pure t,
+          e <- fault start
+      ],
+      -- fault in end: propagate
+      [ e
+        | For _ start end _ <- pure t,
+          _ <- val start,
+          e <- fault end
+      ]
+    ]
+
+reduceRead :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceRead t =
+  asum
+    [ -- Read operation
+      [ r
+        | Read s <- pure t,
+          Happy input <- envR inputVal, -- Can inputVal fail?
+          r <- envR (setVar s input)
+      ]
+    ]
+
+reduceWrite :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceWrite t =
+  asum
+    [ -- step expr
+      [ Continue (Write expr')
+        | Write expr <- pure t,
+          expr' <- step expr
+      ],
+      -- Write operation
+      [ r
+        | Write expr <- pure t,
+          v <- val expr,
+          r <- envR (outputVal v)
+      ],
+      -- fault in expr: propagate
+      [ e
+        | Write expr <- pure t,
+          e <- fault expr
+      ]
+    ]
+
+reduceSkip :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceSkip t = [Happy (IntVal 0) | Skip <- pure t]
+
+reduceBinaryOps :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceBinaryOps t =
+  asum
+    [ -- step t1
+      [ Continue (BinaryOps op t1' t2)
+        | BinaryOps op t1 t2 <- pure t,
+          t1' <- step t1
+      ],
+      -- t1 is a value: step t2
+      [ Continue (BinaryOps op t1 t2')
+        | BinaryOps op t1 t2 <- pure t,
+          _ <- val t1,
+          t2' <- step t2
+      ],
+      -- both t1 and t2 are values: perform operation
+      [ r
+        | BinaryOps op t1 t2 <- pure t,
+          v1 <- val t1,
+          v2 <- val t2,
+          r <- envR (applyBinaryOp op v1 v2)
+      ],
+      -- fault in t1: propagate
+      [ e
+        | BinaryOps _ t1 _ <- pure t,
+          e <- fault t1
+      ],
+      -- fault in t2: propagate
+      [ e
+        | BinaryOps _ t1 t2 <- pure t,
+          _ <- val t1,
+          e <- fault t2
+      ]
+    ]
   where
     applyBinaryOp Add = addVal
     applyBinaryOp Sub = subVal
@@ -232,66 +585,144 @@ reduce_ (BinaryOps op t1 t2) =
     applyBinaryOp And = andVal
     applyBinaryOp Or = orVal
     applyBinaryOp Xor = xorVal
-reduce_ (BoolLit b) =
-  return $ Happy $ BoolVal b
-reduce_ (UnaryOps op t) =
-  premise
-    (reduce t)
-    (UnaryOps op)
-    (applyUnaryOp op)
+
+reduceUnaryOps :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceUnaryOps t =
+  asum
+    [ -- step t
+      [ Continue (UnaryOps op rhs')
+        | UnaryOps op rhs <- pure t,
+          rhs' <- step rhs
+      ],
+      -- t is a value: perform operation
+      [ r
+        | UnaryOps op rhs <- pure t,
+          v <- val rhs,
+          r <- envR (applyUnaryOp op v)
+      ],
+      -- fault in t: propagate
+      [ e
+        | UnaryOps _ rhs <- pure t,
+          e <- fault rhs
+      ]
+    ]
   where
     applyUnaryOp Neg = negVal
     applyUnaryOp Not = notVal
     applyUnaryOp BitNot = bitNotVal
-reduce_ BreakSignal =
-  return $ Continue BreakSignal
-reduce_ ContinueSignal =
-  return $ Continue ContinueSignal
-reduce_ (Fun xs t) = do
-  env <- S.get
-  let vars = getScope env
-  return $ Happy (ClosureVal xs t vars)
-reduce_ (ApplyFun tf tas) =
-  premise
-    (reduce tf)
-    (`ApplyFun` tas)
-    (reduceArgsAndApply tf tas)
-reduce_ (PreIncrement x) =
-  preIncrementVal x
-reduce_ (PreDecrement x) =
-  preDecrementVal x
-reduce_ (PostIncrement x) =
-  postIncrementVal x
-reduce_ (PostDecrement x) =
-  postDecrementVal x
-reduce_ (TupleTerm elements) =
-  case elements of
-    (x : xs) ->
-      premise
-        (reduce x)
-        (\term' -> TupleTerm $ term' : xs)
-        ( \v1 ->
-            premise
-              (reduce $ TupleTerm xs)
-              ( \case
-                  TupleTerm xs' -> TupleTerm (x : xs')
-                  _ -> error "TupleTerm recursion somehow returned a non TupleTerm continuation"
-              )
-              (\v2 -> return $ Happy $ Tuple $ v1 : fromRight [] (valueToTuple v2))
-        )
-    [] -> return $ Happy $ Tuple []
-reduce_ NewDictionary =
-  return $ Happy $ Dictionary M.empty
 
-reduceArgsAndApply :: (Machine m, Show m, V m ~ Value) => Term -> [Term] -> Value -> Env m
+reduceBreakContinue :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceBreakContinue t =
+  asum
+    [ [Continue BreakSignal | BreakSignal <- pure t],
+      [Continue ContinueSignal | ContinueSignal <- pure t]
+    ]
+
+reduceIncDec :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceIncDec t =
+  asum
+    [ [r | PreIncrement x <- pure t, r <- envR (preIncrementVal x)],
+      [r | PreDecrement x <- pure t, r <- envR (preDecrementVal x)],
+      [r | PostIncrement x <- pure t, r <- envR (postIncrementVal x)],
+      [r | PostDecrement x <- pure t, r <- envR (postDecrementVal x)]
+    ]
+
+-- reduce_ (Fun xs t) = do
+--   env <- S.get
+--   let vars = getScope env
+--   return $ Happy (ClosureVal xs t vars)
+reduceFun :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceFun t =
+  asum
+    [ [ Happy (ClosureVal xs body vars)
+        | Fun xs body <- pure t,
+          env <- S.get,
+          let vars = getScope env
+      ]
+    ]
+
+reduceApplyFun :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceApplyFun t =
+  asum
+    [ -- (1) Step the function position first
+      [ Continue (ApplyFun tf' tas)
+        | ApplyFun tf tas <- pure t,
+          tf' <- step tf
+      ],
+      -- (2) Function position fault: propagate
+      [ e
+        | ApplyFun tf _ <- pure t,
+          e <- fault tf
+      ],
+      -- (3) Function is a value, zero args: run applyFuncNoArg
+      --     (handles both ClosureVal and non-function errors)
+      [ r
+        | ApplyFun tf [] <- pure t,
+          fval <- val tf,
+          r <- envR (applyFuncNoArg fval)
+      ],
+      -- (4) Function is a value, there are args: step the first arg (left-to-right)
+      [ Continue (ApplyFun tf (a' : as))
+        | ApplyFun tf (a : as) <- pure t,
+          _ <- val tf, -- only step args once tf is a value
+          a' <- step a
+      ],
+      -- (5) First arg is now a value: consume exactly one argument via applyFunArgList
+      --     (this handles: too many args, non-function, partial application, body eval)
+      [ r
+        | ApplyFun tf (a : as) <- pure t,
+          fval <- val tf,
+          aval <- val a,
+          r <- envR (applyFunArgList tf as fval aval)
+      ]
+    ]
+
+-- Reduce/apply one argument at a time (left-to-right), small-step style.
+-- This is what your rules should call.
+reduceArgsAndApplyR ::
+  (Machine m, Show m, V m ~ Value) =>
+  -- | tf  (function term, used only to rebuild the frame)
+  Term ->
+  -- | args
+  [Term] ->
+  -- | funVal (already evaluated function value)
+  Value ->
+  Reduction m (Result (V m))
+reduceArgsAndApplyR _ [] funVal =
+  -- zero arguments: defer to your existing helper
+  [r | r <- envR (applyFuncNoArg funVal)]
+reduceArgsAndApplyR tf (a : rest) funVal =
+  asum
+    [ -- step the next arg
+      [ Continue (ApplyFun tf (a' : rest))
+        | a' <- step a
+      ],
+      -- arg is a value: consume exactly one argument via your helper
+      [ r
+        | aval <- val a,
+          r <- envR (applyFunArgList tf rest funVal aval)
+      ],
+      -- propagate a fault from the arg
+      [ e
+        | e <- fault a
+      ]
+    ]
+
+runRToEnv :: Reduction m (Result (V m)) -> Env m
+runRToEnv r = S.state $ \s ->
+  case S.runStateT (runRed r) s of
+    Nothing -> (Sad (Internal, "stuck in reduceArgsAndApplyR"), s)
+    Just (x, s') -> (x, s')
+
+-- Back-compat name with original type:
+reduceArgsAndApply ::
+  (Machine m, Show m, V m ~ Value) =>
+  Term ->
+  [Term] ->
+  Value ->
+  Env m
 reduceArgsAndApply tf args funVal =
-  case args of
-    [] -> applyFuncNoArg funVal
-    (a : rest) ->
-      premise
-        (reduce a)
-        (\a' -> ApplyFun tf (a' : rest))
-        (applyFunArgList tf rest funVal)
+  runRToEnv (reduceArgsAndApplyR tf args funVal)
 
 applyFunArgList :: (Machine m, Show m, V m ~ Value) => Term -> [Term] -> Value -> Value -> Env m
 applyFunArgList tf rest funVal argVal = do
@@ -304,7 +735,7 @@ applyFunArgList tf rest funVal argVal = do
     Sad msg -> return (Sad msg)
 
 applyFunArg :: (Machine m, Show m, V m ~ Value) => Value -> Value -> Env m
-applyFunArg (ClosureVal [] _ _) _ =
+applyFunArg (ClosureVal [] _ _) _ = do
   return $ Sad (Arguments, "too many arguments: function takes 0 arguments")
 applyFunArg (ClosureVal (x : xs) body caps) arg = do
   let newCaps = caps ++ [(x, arg)]
@@ -341,7 +772,50 @@ bindMany ((k, v) : rest) m =
     (Continue _, _m') -> Left (Arguments, "internal: setVar requested Continue")
     (Happy _, m') -> bindMany rest m'
 
-reduce :: (Machine m, Show m, V m ~ Value) => Term -> Env m
+reduceTupleTerm :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceTupleTerm t =
+  asum
+    [ -- non-empty tuple: step first element
+      [ Continue (TupleTerm (elm' : elms))
+        | TupleTerm (elm : elms) <- pure t,
+          elm' <- step elm
+      ],
+      -- first element is a value: step rest of tuple
+      [ Continue (TupleTerm (elm : elms'))
+        | TupleTerm (elm : elms) <- pure t,
+          _ <- val elm,
+          TupleTerm elms' <- step (TupleTerm elms)
+      ],
+      -- all elements are values: construct tuple value
+      [ Happy (Tuple vs)
+        | TupleTerm elms <- pure t,
+          vs <- mapM val elms
+      ],
+      -- fault in first element: propagate
+      [ e
+        | TupleTerm (elm : _) <- pure t,
+          e <- fault elm
+      ],
+      -- fault in rest of tuple: propagate
+      [ e
+        | TupleTerm (_ : elms) <- pure t,
+          _ <- val (head elms),
+          e <- fault (TupleTerm elms)
+      ],
+      -- empty tuple: return empty tuple value
+      [ r
+        | TupleTerm [] <- pure t,
+          r <- envR (return $ Happy $ Tuple [])
+      ]
+    ]
+
+reduceDictionary :: (Machine m, Show m, V m ~ Value) => Rule m
+reduceDictionary t =
+  asum
+    [ [r | NewDictionary <- pure t, r <- envR (return $ Happy $ Dictionary M.empty)]
+    ]
+
+reduce :: (Machine m, Show m, V m ~ Value) => Rule m
 reduce t = do
   e <- S.get
   trace ("Simulating: " ++ show t) () `seq`
@@ -349,12 +823,17 @@ reduce t = do
       reduce_ t
 
 reduceFully :: (Machine m, Show m, V m ~ Value) => Term -> m -> (Either String (V m), m)
-reduceFully term machine =
-  case S.runState (reduce term) machine of
-    (Sad (_, message), m) -> (Left message, m)
-    (Continue t, m) ->
-      case t of
-        BreakSignal -> (Left "unhandled break signal", m)
-        ContinueSignal -> (Left "unhandled continue signal", m)
-        _ -> reduceFully t m
-    (Happy n, m) -> (Right n, m)
+reduceFully term0 m0 = go m0 term0
+  where
+    go st t =
+      case S.runStateT (runRed (reduce t)) st of
+        -- show stuck term
+        Nothing -> (Left ("stuck term: " ++ show t), st)
+        Just (Happy v, st') -> (Right v, st')
+        Just (Sad (_, msg), st') -> (Left msg, st')
+        Just (Continue t', st') ->
+          -- handle special signals (your AST constructors)
+          case t' of
+            BreakSignal -> (Left "unhandled break signal", st')
+            ContinueSignal -> (Left "unhandled continue signal", st')
+            _ -> go st' t'

--- a/Term.hs
+++ b/Term.hs
@@ -12,7 +12,7 @@ data BinaryOp = Add | Sub | Mul | Div | Mod | Lt | Gt | Lte | Gte | Eq | Neq | A
 data UnaryOp = Neg | Not | BitNot
   deriving (Eq, Show)
 
-data ErrorKind = Arithmetic | Type | Input | VariableNotFound | Arguments deriving (Eq, Show)
+data ErrorKind = Arithmetic | Type | Input | VariableNotFound | Arguments | Internal deriving (Eq, Show)
 
 data ErrorKindOrAny = Specific ErrorKind | Any deriving (Eq, Show)
 
@@ -31,6 +31,7 @@ data Term
   | OnlyStr String
   | Bracket Term Term
   | While Term Term
+  | For String Term Term Term
   | Write Term
   | BoolLit Bool
   | TupleTerm [Term]


### PR DESCRIPTION
Big refactor of Small.hs for fixing #96. Currently passes all tests, but should be reviewed further. Also includes for loops.

Some concerns
- We lose some of haskell's exhaustive pattern matching by doing runtime checks for rules
- Probably could be simplified even further. Gheith's example was extremely clean
- Maybe a better abstraction for step/val?
- Also not necessary to pattern match the term everywhere? It would be nice for that to be implicit