### PR TITLE
refactor: ensure spec consistent across simulator and smallspec

### DIFF
--- a/Simulator.hs
+++ b/Simulator.hs
@@ -245,6 +245,7 @@ instance Machine Simulator where
              in case returnVal of
                   Right (Tuple rest) -> Right $ Tuple (x : rest)
                   _ -> returnVal
+      loop (Tuple []) (IntVal _) _ = Left (VariableNotFound, "Attempting to set value Out of Bounds")
       loop _ _ _ = error "unreachable hopefully"
   setBracketValue _ _ _ = return $ Sad (Type, "Had a Type Error")
 


### PR DESCRIPTION
Mostly just updated SmallSpec.hs to include the spec from Simulator.hs, which people appear to have been using for test cases. This includes things like allowing adding strings together and other operations on strings that SmallSpec.hs did not have (but Simulator.hs did).