### PR TITLE
Make funCall support typedIndent the way methodCall does

### DIFF
--- a/FunSyntax.hs
+++ b/FunSyntax.hs
@@ -234,12 +234,14 @@ funDef :: Parser Token Term
 funDef =
   -- a named function
 
-  [ Let (OnlyStr (name, TFun (snd <$> params) TUnknown)) (Fun params body)
+  [ Let (OnlyStr (name, TFun (snd <$> params) retType)) (Fun params body)
     | _ <- keyword "fun",
       name <- ident,
       _ <- symbol "(",
       params <- rptDropSep typedIdent (symbol ","),
       _ <- symbol ")",
+      maybeRetType <- opt (symbol "->" >> typeSignature),
+      let retType = fromMaybe TUnknown maybeRetType,
       body <- term
   ]
     <|>


### PR DESCRIPTION
The syntax for method calls supports type annotations:
`a.f : fun(x,y,z) -> w (b,c)` is valid, compiling to `call f(a,b,c)` and ensuring that `f` is a function of type `fun(x,y,z) -> w`.

However, the same syntax is not allowed for normal function calls:
`call f: fun(x,y,z) -> w (a,b,c)` fails to compile.

Currently, my test case includes the syntax for type annotations on method calls, which results in a compilation error when it tries to decompile the AST, because it decompiles into a normal function call, which is invalid syntax.

One of these two ought to be changed for consistency, and I propose that we allow function calls to have types. Since all variable references are allowed to be typed, the same should go for functions. Thus, I made the `funCall` term parse a `typedIdent` rather than a normal `ident`.